### PR TITLE
Optimization for kestrel memory usage

### DIFF
--- a/template/csharp-kestrel/root.csproj
+++ b/template/csharp-kestrel/root.csproj
@@ -8,4 +8,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.5" />
   </ItemGroup>
+  <PropertyGroup> 
+    <ServerGarbageCollection>false</ServerGarbageCollection>
+  </PropertyGroup>
 </Project>


### PR DESCRIPTION
I tried your template and I noticed the memory usage. After 1000 request the memory keeps at 38 MB.
If you disable the ServerGarbageCollection the memory keeps at 28 MB.

See also the article:
https://blog.markvincze.com/troubleshooting-high-memory-usage-with-asp-net-core-on-kubernetes/