### PR TITLE
Code cleanups and usage of FaasUtils

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 [Bb]in/
 [Oo]bj/
 [Pp]ublished/
+build/

--- a/template/csharp-http/Dockerfile
+++ b/template/csharp-http/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/core/sdk:2.1 AS builder
+FROM mcr.microsoft.com/dotnet/core/sdk:2.2 AS builder
 
 ENV DOTNET_CLI_TELEMETRY_OPTOUT 1
 
@@ -16,7 +16,7 @@ COPY .  .
 
 RUN dotnet publish -c release -o published
 
-FROM mcr.microsoft.com/dotnet/core/aspnet:2.1
+FROM mcr.microsoft.com/dotnet/core/aspnet:2.2
 
 RUN apt-get update -qy \
     && apt-get install -qy curl ca-certificates --no-install-recommends \ 

--- a/template/csharp-http/FaasMiddleware.cs
+++ b/template/csharp-http/FaasMiddleware.cs
@@ -1,0 +1,59 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading.Tasks;
+using Function;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Primitives;
+using Newtonsoft.Json;
+using OpenFaaS.FunctionSDK;
+
+namespace root
+{
+	public class FaasMiddleware
+	{
+		public FaasMiddleware(RequestDelegate next)
+		{
+		}
+
+		public async Task InvokeAsync(HttpContext context, FunctionContext fnContext)
+		{
+			var functionHandler = new FunctionHandler();
+			try
+			{
+				// execute the function
+				var result = await functionHandler.Handle(fnContext);
+
+				// set the response from the FunctionResponse
+				context.Response.ContentType = "application/json";
+				context.Response.StatusCode = result.StatusCode.ToStatusInt();
+
+				// if headers were set, convert to the proper type and set the response
+				if (result.Headers != null && result.Headers.Count > 0)
+				{
+					foreach (var head in result.Headers.AllKeys)
+					{
+						context.Response.Headers.Add(new KeyValuePair<string, StringValues>(head, result.Headers[head]));
+					}
+				}
+
+				// set the response body. Assume object if it's not a stream
+				if (result.Body.GetType() == typeof(Stream))
+				{
+					context.Response.Body = (Stream)result.Body;
+				}
+				else
+				{
+					await context.Response.WriteAsync(JsonConvert.SerializeObject(result.Body));
+				}
+			}
+			catch (Exception ex)
+			{
+				// if there's an error, return appropriate response code and the exception message
+				context.Response.StatusCode = 500;
+				context.Response.ContentType = "application/json";
+				await context.Response.WriteAsync(JsonConvert.SerializeObject(new { Error = ex.Message }));
+			}
+		}
+	}
+}

--- a/template/csharp-http/FunctionContextFactory.cs
+++ b/template/csharp-http/FunctionContextFactory.cs
@@ -1,0 +1,72 @@
+﻿using System;
+using System.Collections.Specialized;
+using System.IO;
+using System.Net.Http;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.DependencyInjection;
+using Newtonsoft.Json;
+using OpenFaaS.FunctionSDK;
+
+namespace root
+{
+	public static class FunctionContextFactory
+	{
+		public static FunctionContext Create(IServiceProvider provider)
+		{
+			// Ideally this should use constructor injection in FunctionContext instead...
+			var context = provider.GetRequiredService<IHttpContextAccessor>().HttpContext;
+
+			// extract the request information
+			var requestBody = getRequest(context);
+			var requestHeaders = getHeaders(context);
+			var requestQueries = getQuery(context);
+
+			// set the context to pass to the function
+			return new FunctionContext
+			{
+				Body = requestBody,
+				Headers = requestHeaders,
+				Method = new HttpMethod(context.Request.Method),
+				QueryString = requestQueries
+			};
+		}
+
+		private static object getRequest(HttpContext context)
+		{
+			StreamReader reader = new StreamReader(context.Request.Body);
+			string sBody = reader.ReadToEnd();
+			object body = sBody;
+
+			// If the request is JSON, convert it to a JObject for easy deserialization in the handler
+			if (sBody.Length > 0 && sBody[0] == '{')
+			{
+				body = JsonConvert.DeserializeObject(sBody);
+			}
+
+			return body;
+		}
+
+		private static NameValueCollection getHeaders(HttpContext context)
+		{
+			var results = new NameValueCollection();
+			var headers = context.Request.Headers;
+			foreach (var h in headers)
+			{
+				results.Add(h.Key, string.Join('|', h.Value));
+			}
+			return results;
+		}
+
+		private static NameValueCollection getQuery(HttpContext context)
+		{
+			var queries = new NameValueCollection();
+			var reqQuery = context.Request.Query;
+
+			foreach (var q in reqQuery)
+			{
+				queries.Add(q.Key, string.Join('|', q.Value));
+			}
+			return queries;
+		}
+	}
+}

--- a/template/csharp-http/Startup.cs
+++ b/template/csharp-http/Startup.cs
@@ -1,19 +1,7 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Collections.Specialized;
-using System.IO;
-using System.Linq;
-using System.Net;
-using System.Net.Http;
-using System.Text;
-using System.Threading.Tasks;
-using Function;
-using Microsoft.AspNetCore.Builder;
+﻿using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Primitives;
-using Newtonsoft.Json;
 using OpenFaaS.FunctionSDK;
 
 namespace root
@@ -22,6 +10,8 @@ namespace root
     {
         public void ConfigureServices(IServiceCollection services)
         {
+	        services.AddSingleton<IHttpContextAccessor, HttpContextAccessor>();
+	        services.AddScoped<FunctionContext>(FunctionContextFactory.Create);
         }
 
         public void Configure(IApplicationBuilder app, IHostingEnvironment env)
@@ -31,97 +21,7 @@ namespace root
                 app.UseDeveloperExceptionPage();
             }
 
-            app.Run(async (context) =>
-            {
-                var functionHandler = new FunctionHandler();
-                try
-                {
-                    // extract the request information
-                    var requestBody = getRequest(context);
-                    var requestHeaders = getHeaders(context);
-                    var requestQueries = getQuery(context);
-
-                    // set the context to pass to the function
-                    var fnContext = new FunctionContext
-                    {
-                        Body = requestBody,
-                        Headers = requestHeaders,
-                        Method = new HttpMethod(context.Request.Method),
-                        QueryString = requestQueries
-                    };
-
-                    // execute the function
-                    var result = await functionHandler.Handle(fnContext);
-                    
-                    // set the response from the FunctionResponse
-                    context.Response.ContentType = "application/json";
-                    context.Response.StatusCode = result.StatusCode.ToStatusInt();
-
-                    // if headers were set, convert to the proper type and set the response
-                    if (result.Headers != null && result.Headers.Count > 0)
-                    {
-                        foreach (var head in result.Headers.AllKeys)
-                        {
-                            context.Response.Headers.Add(new KeyValuePair<string, StringValues>(head, result.Headers[head]));
-                        }
-                    }
-
-                    // set the response body. Assume object if it's not a stream
-                    if (result.Body.GetType() == typeof(Stream))
-                    {
-                        context.Response.Body = (Stream)result.Body;
-                    }
-                    else
-                    {
-                        await context.Response.WriteAsync(JsonConvert.SerializeObject(result.Body));
-                    }
-                }
-                catch (Exception ex)
-                {
-                    // if there's an error, return appropriate response code and the exception message
-                    context.Response.StatusCode = 500;
-                    context.Response.ContentType = "application/json";                    
-                    await context.Response.WriteAsync(JsonConvert.SerializeObject(new { Error = ex.Message }));
-                }
-            });
-        }
-
-        private object getRequest(HttpContext context)
-        {
-            StreamReader reader = new StreamReader(context.Request.Body);
-            string sBody = reader.ReadToEnd();
-            object body = sBody;
-
-            // If the request is JSON, convert it to a JObject for easy deserialization in the handler
-            if (sBody[0] == '{')
-            {
-                body = JsonConvert.DeserializeObject(sBody);
-            }
-
-            return body;
-        }
-
-        private NameValueCollection getHeaders(HttpContext context)
-        {
-            var results = new NameValueCollection();
-            var headers = context.Request.Headers;
-            foreach (var h in headers)
-            {
-                results.Add(h.Key, string.Join('|', h.Value));
-            }
-            return results;
-        }
-
-        private NameValueCollection getQuery(HttpContext context)
-        {
-            var queries = new NameValueCollection();
-            var reqQuery = context.Request.Query;
-
-            foreach (var q in reqQuery)
-            {
-                queries.Add(q.Key, string.Join('|', q.Value));
-            }
-            return queries;
+            app.UseMiddleware<FaasMiddleware>();
         }
     }
 }

--- a/template/csharp-http/Startup.cs
+++ b/template/csharp-http/Startup.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Builder;
+﻿using FaasUtils.Extensions;
+using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.DependencyInjection;
@@ -10,6 +11,7 @@ namespace root
     {
         public void ConfigureServices(IServiceCollection services)
         {
+	        services.AddFaasUtils();
 	        services.AddSingleton<IHttpContextAccessor, HttpContextAccessor>();
 	        services.AddScoped<FunctionContext>(FunctionContextFactory.Create);
         }

--- a/template/csharp-http/function/FunctionHandler.cs
+++ b/template/csharp-http/function/FunctionHandler.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Specialized;
-using System.Net;
-using System.Net.Http;
+﻿using System.Collections.Specialized;
 using System.Threading.Tasks;
 using OpenFaaS.FunctionSDK;
 
@@ -30,24 +27,22 @@ namespace Function
 
     public class FunctionHandler
     {
-        public Task<FunctionResponse> Handle(FunctionContext fnContext)
+		// Sample: use a custom request type by taking an object as an argument
+		//public Task<FunctionResponse> InvokeAsync(SampleRequest input)
+		public Task<FunctionResponse> InvokeAsync(string input)
         {
             // Sample: Set custom headers
             var resultHeaders = new NameValueCollection
             {
                 {"X-OpenFaaS-Function", "csharp-kestrel"},
             };
-
-            // Sample: use a custom request type by casting the fnContext.Body to JObject and deserializing it
-            // var jBody = (JObject)fnContext.Body;
-            // SampleRequest req = jBody.ToObject<SampleRequest>();
             
             var result = new FunctionResponse {
                 // Sample: Return plain text, or a custom object as the body
                 // Body = $"Hello from OpenFaaS + Kestrel, {fnContext.Body}!",
                 Body = new SampleResponse
                 {
-                    Response = $"Hello from OpenFaaS + Kestrel, {fnContext.Body}"
+                    Response = $"Hello from OpenFaaS + Kestrel, {input}"
                 },
                 Headers = resultHeaders
             };

--- a/template/csharp-http/function/FunctionHandler.csproj
+++ b/template/csharp-http/function/FunctionHandler.csproj
@@ -7,5 +7,6 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="OpenFaas.FunctionSDK" Version="0.0.2" />
+    <PackageReference Include="FaasUtils" Version="1.0.0" />
   </ItemGroup>
 </Project>

--- a/template/csharp-http/root.csproj
+++ b/template/csharp-http/root.csproj
@@ -6,6 +6,7 @@
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>
   <ItemGroup>
+    <PackageReference Include="FaasUtils" Version="1.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.All" />
     <PackageReference Include="OpenFaas.FunctionSDK" Version="0.0.2" />
   </ItemGroup>

--- a/template/csharp-http/root.csproj
+++ b/template/csharp-http/root.csproj
@@ -1,12 +1,12 @@
-<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp2.2</TargetFramework>
   </PropertyGroup>
   <PropertyGroup>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.5" />
+    <PackageReference Include="Microsoft.AspNetCore.All" />
     <PackageReference Include="OpenFaas.FunctionSDK" Version="0.0.2" />
   </ItemGroup>
   <PropertyGroup> 

--- a/template/csharp-http/template.yml
+++ b/template/csharp-http/template.yml
@@ -1,5 +1,5 @@
 language: csharp-kestrel
 fprocess: dotnet ./root.dll
 welcome_message: |
-  You have created a new function which uses .NET Core 2.1.
+  You have created a new function which uses .NET Core 2.2.
   dotnet add package can be used to add extra libraries


### PR DESCRIPTION
- Upgrade to .NET Core 2.2
- Split middleware from `app.Use` out into a separate class. This allows the use of dependency injection and would make unit testing easier.
- Use `ActivatorUtilities.CreateInstance` when creating `FunctionHandler` so that dependencies can be injected into the constructor
- Create one singleton instance of the function handler, rather than one instance per execution. This should be more efficient for functions that receive a lot of calls, as it will ease GC pressure. This is consistent with how .NET Core handles middleware - One single instance of the middleware is created. Per-instance dependencies could still be used by adding them as arguments to the `InvokeAsync` method directly
- Inject `FunctionContext` into middleware rather than creating the instance inline (separation of concerns)
- Use [FaasUtils](https://d.sb/faasutils) for executing the function. This allows more flexibility as it parses out the arguments to the function and handles them more specifically (eg. a `string` argument named `input` will take the raw POST body)

References #11